### PR TITLE
Add new ATAOS configuration with hexapod LUTs computed with data take…

### DIFF
--- a/ATAOS/v3/_labels.yaml
+++ b/ATAOS/v3/_labels.yaml
@@ -1,4 +1,6 @@
 # Labels for recommended settings; a dict of label: config_file
-current: hex_m1_hex_202102_v3.yaml
+current: hex_m1_hex_20210218_v3.yaml
+hex_m1_202102: hex_m1_hex_20210218_v3.yaml
+hex_202003_m1_202102: hex_m1_hex_202102_v3.yaml
 hex_m1_202003: hex_m1_hex_202003_v3.yaml
 constant_hex: hex_m1_202003_constant_hex_v3.yaml

--- a/ATAOS/v3/hex_m1_hex_20210218_v3.yaml
+++ b/ATAOS/v3/hex_m1_hex_20210218_v3.yaml
@@ -3,6 +3,9 @@
 # Description: DM-28826 Support AT observing run
 #   Data taken on the summit still pending validation.
 #   New M1 pressure LUT with data taken on 20210216
+#   New Hexapod LUT obtained by combining old data (taken for 202003
+#   configuration) plus additional data taken on 20210217. Only data with
+#   elevation larger than 50 degrees was used from the 202003 dataset.
 
 correction_frequency: 1.
 
@@ -15,27 +18,25 @@ m2:
   - 0.
 
 hexapod_x:
-  -         +6.285
-  -        -20.969
-  -        +27.138
-  -        -16.115
-  -         -1.535
+  -    -214.840283
+  -    +715.670761
+  -    -893.780676
+  -    +516.399689
+  -    -139.496624
+  -     +10.872385
 
 hexapod_y:
-  -         -1.741
-  -         +3.850
-  -         -3.158
-  -         +1.767
+  -      -0.658659
+  -      -0.146944
+  -      +1.461427
 
 hexapod_z:
-  -       -279.386
-  -      +1676.871
-  -      -4064.106
-  -      +5214.778
-  -      -3855.691
-  -      +1654.010
-  -       -384.112
-  -        +38.008
+  -     +30.312426
+  -     -88.648850
+  -     +88.139997
+  -     -30.217845
+  -      -1.065925
+  -      +1.835957
 
 hexapod_u:
   - 0.3500


### PR DESCRIPTION
…n in 20210217 combined with data taken in 202003.

Only data with elevation larger than 50 degrees was used from the 202003 dataset.